### PR TITLE
[IMP] project_task_billable_hours : display billable_remaining_hours instead of remaining_hours in project kanban view

### DIFF
--- a/project_task_billable_hours/__manifest__.py
+++ b/project_task_billable_hours/__manifest__.py
@@ -17,7 +17,8 @@
         "project_working_time_task_portal"
     ],
     "data": [
-        "views/project_task_views.xml",        
+        "views/project_task_views.xml",
+        "views/project_views.xml"
     ],
     "installable": True,
     "application": False,

--- a/project_task_billable_hours/models/__init__.py
+++ b/project_task_billable_hours/models/__init__.py
@@ -1,0 +1,1 @@
+from . import billable_time

--- a/project_task_billable_hours/models/billable_time.py
+++ b/project_task_billable_hours/models/billable_time.py
@@ -1,0 +1,16 @@
+from odoo import models, fields, api
+
+class Project(models.Model):
+    _inherit = "project.project"
+
+    billable_remaining_hours = fields.Float(
+        compute="_compute_project_billable_remaining_hours",
+        string="Billable Remaining Hours",
+        store=True,
+        help="Total Billable remaining time (without exclude_from_sale_order timesheet lines)."
+    )
+
+    @api.depends("task_ids.billable_remaining_hours")
+    def _compute_project_billable_remaining_hours(self):
+        for project in self:
+            project.billable_remaining_hours = sum(task.billable_remaining_hours for task in project.task_ids)

--- a/project_task_billable_hours/views/project_views.xml
+++ b/project_task_billable_hours/views/project_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="project_working_time_view_project_kanban" model="ir.ui.view">
+        <field name="name">project.working.time.view.project.kanban</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="hr_timesheet.view_project_kanban_inherited" />
+        <field name="priority" eval="999" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('o_project_kanban_boxes')]/following-sibling::div[1]" position="replace">
+                <t t-set="badgeColor" t-value="'border-success'"/>
+                <t t-set="badgeColor" t-value="'border-danger'" t-if="record.billable_remaining_hours.raw_value &lt; 0"/>
+                <div t-if="record.allow_timesheets.raw_value and record.allocated_hours.raw_value &gt; 0"
+                     t-attf-class="oe_kanban_align badge border {{ badgeColor }}" title="Billable remaining hours" groups="hr_timesheet.group_hr_timesheet_user">
+                    <field name="billable_remaining_hours" widget="timesheet_uom"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New PR following comments on this one https://github.com/elabore-coop/project-tools/pull/25

Task : https://lokavaluto.fr/web?debug=1#id=2526&cids=1&menu_id=144&action=977&model=project.task&view_type=form